### PR TITLE
Fixing downloads and tweaking gas

### DIFF
--- a/src/classes/storageHandler.ts
+++ b/src/classes/storageHandler.ts
@@ -991,11 +991,10 @@ export class StorageHandler extends EncodingHandler implements IStorageHandler {
     try {
       const particulars = await this.getFileParticulars(filePath)
       const providerList = shuffleArray(particulars.providerIps)
-      const provider =
-        providerList[Math.floor(Math.random() * providerList.length)]
-      const url = `${provider}/download/${particulars.merkleLocation}`
-
       for (const _ of providerList) {
+        const provider =
+          providerList[Math.floor(Math.random() * providerList.length)]
+        const url = `${provider}/download/${particulars.merkleLocation}`
         try {
           const resp = await fetch(url, { method: 'GET' })
           const contentLength = resp.headers.get('Content-Length')

--- a/src/utils/gas.ts
+++ b/src/utils/gas.ts
@@ -5,7 +5,7 @@ const gasBaselineRate = 56
 const gasFallbackTxCost = 142
 const gasMap: Record<string, number> = {
   /** Filetree */
-  '/canine_chain.filetree.MsgPostFile': 210,
+  '/canine_chain.filetree.MsgPostFile': 270,
   '/canine_chain.filetree.MsgPostKey': 12,
   '/canine_chain.filetree.MsgDeleteFile': 9,
   /** Notifications */


### PR DESCRIPTION
Downloads would only look at the first provider in the list and fail if it wasn't available.

Renames were being bad with gas prices so I bumped it proportionally. 